### PR TITLE
Collections Menu and Loading screen

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,12 +6,63 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>API Explorer</title>
     <link rel="stylesheet" href="/styles/default.min.css">
+    <link rel="stylesheet" href="/styles/default.min.css">
     <link rel="stylesheet" href="/styles/androidstudio.min.css">
     <script src="/js/highlight.min.js"></script>
     <script src="/js/highlightjs-line-numbers.min.js"></script>
+    <style>
+      .loading-page {
+        display: flex;
+        align-items: center;
+        flex-direction: column;
+      }
+
+      .messages {
+        width: 80%;
+        height: 100px;
+        background-color: #e3e3e3;
+        margin: 100px auto;
+        padding: 5px;
+      }
+
+      .lds-dual-ring {
+        display: inline-block;
+        position: relative;
+        width: 80px;
+        height: 80px;
+      }
+      .lds-dual-ring:after {
+        content: " ";
+        display: block;
+        width: 64px;
+        height: 64px;
+        margin: 8px;
+        border-radius: 50%;
+        border: 6px solid #50b164;
+        border-color: #50b164 transparent #50b164 transparent;
+        animation: lds-dual-ring 1.2s linear infinite;
+      }
+      @keyframes lds-dual-ring {
+        0% {
+          transform: rotate(0deg);
+        }
+        100% {
+          transform: rotate(360deg);
+        }
+      }
+    </style>
   </head>
   <body>
-    <div id="app"><center>Loading...<center></div>
+    
+    
+    <div id="app">
+      <div class="loading-page">
+        <img src="/src/assets/logo2x-1.png" style="margin-top: 50px;">
+        <div class="lds-dual-ring"></div>
+        <div class="loading-messages"><p>Loading...</p></div>
+      </div>
+    </div>
+    
     <script type="module" src="/src/main.ts"></script>
   </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -30,6 +30,7 @@
         position: relative;
         width: 80px;
         height: 80px;
+        margin-top: 15px;
       }
       .lds-dual-ring:after {
         content: " ";
@@ -57,9 +58,8 @@
     
     <div id="app">
       <div class="loading-page">
-        <img src="/src/assets/logo2x-1.png" style="margin-top: 50px;">
+        <img src="/src/assets/logo2x-1.png" style="width: 304px; margin-top: 50px;">
         <div class="lds-dual-ring"></div>
-        <div class="loading-messages"><p>Loading...</p></div>
       </div>
     </div>
     

--- a/server/app.ts
+++ b/server/app.ts
@@ -13,7 +13,12 @@ app.use(
   session({
     secret: process.env.VITE_OPB_SERVER_SESSION_PASSWORD,
     resave: false,
-    saveUninitialized: true
+    saveUninitialized: true,
+    cookie: {
+      httpOnly: true,
+      secure: true,
+      maxAge: 300*1000, // 5 minutes in milliseconds
+    }
   })
 )
 useContainer(Container)

--- a/src/components/Collections.vue
+++ b/src/components/Collections.vue
@@ -1,0 +1,59 @@
+<script setup lang="ts">
+import { searchLinksColor as searchLinksColorSetting } from '../obp/style-setting'
+import { inject, ref } from 'vue'
+
+const searchLinksColor = ref(searchLinksColorSetting);
+
+const collectionData = [
+    {
+        "url": "/?api-collection-id=341bf039-97e4-4803-aaae-2d1dc6a5b162",
+        "text": "Risk mgmt. & mitigation"
+    },
+    {
+        "url": "/?api-collection-id=fc3220e5-c891-4943-bbdb-6579ef3889c0",
+        "text": "Process mgmt. & enh."
+    },
+    {
+        "url": "/?api-collection-id=18fa516e-8e52-473c-98c4-430b1043ef4f",
+        "text": "Credit data & scoring"
+    },
+    {
+        "url": "/?api-collection-id=7d4b5f73-9bde-4556-a0ee-ce0f746f833f",
+        "text": "Innovative prods & svcs"
+    },
+    {
+        "url": "/?api-collection-id=cbd97e62-fb8a-42a4-ad5a-139729d11312",
+        "text": "Women-led/owned MSMEs prods & svcs"
+    }
+]
+
+</script>
+
+<template>
+  <el-menu 
+    class="collections-menu"
+    mode="horizontal"
+    background-color="#151d30"
+    text-color="#fff"
+    active-text-color="#52b165">
+        <el-menu-item v-for="(item, index) in collectionData" :index="index">
+            <RouterLink :to="item.url">{{ item.text }}</RouterLink>
+        </el-menu-item>
+    </el-menu>
+</template>
+
+<style scoped>
+a {
+  font-size: 14px;
+  font-family: 'Roboto';
+  color: #7787a6;
+  text-decoration: none;
+}
+
+/* This is not working at the moment, but ideally we would like the color of the menu item to change when hovering.
+a:hover {
+    color: v-bind(searchLinksColor);
+}
+*/
+
+</style>

--- a/src/views/BodyView.vue
+++ b/src/views/BodyView.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import SearchNav from '../components/SearchNav.vue'
 import Menu from '../components/Menu.vue'
+import Collections from '../components/Collections.vue'
 </script>
 
 <template>
@@ -11,6 +12,9 @@ import Menu from '../components/Menu.vue'
     </el-aside>
     <el-main>
       <el-container class="main">
+        <el-header class="collections">
+          <Collections />
+        </el-header>
         <el-header class="menu">
           <Menu />
         </el-header>
@@ -48,5 +52,11 @@ import Menu from '../components/Menu.vue'
   color: white;
   background-color: #151d30;
   max-height: 100vh;
+}
+.collections {
+  margin-left: -20px;
+  margin-right: -20px;
+  padding-left: 20px;
+  padding-right: 20px;
 }
 </style>


### PR DESCRIPTION
A collections menu has been added. At the moment the URLs are for proof of concept and do not do anything. Also, setting the hover text color in the element plus framework seems to be very difficult for some reason. A workaround is needed to make this work for accessibility, or alternatively we have a light coloured menu so that the background highlighting can be seen.

A nice loading page was added. The loading spinner can be changed easily, maybe to create a custom spinner with better branding in future. For now a basic spinner is used, and loads of ideas can be found here: https://cssloaders.github.io/

Settings for session cookies have been added to the server/app.ts, currently this is WIP and does not fully work yet. Also the session timeout is hard-coded, to be changed to take its value from the suggested session timeout endpoint: https://test-explorer.openbankproject.com/?tags=&locale=en_GB#OBPv5_1_0-suggestedSessionTimeout.