### PR TITLE
feat: show resolved request URL on Preview page

### DIFF
--- a/src/components/Preview.vue
+++ b/src/components/Preview.vue
@@ -26,7 +26,7 @@
   -->
 
 <script setup lang="ts">
-import { ref, reactive, inject, onBeforeMount, onMounted, onUnmounted } from 'vue'
+import { ref, reactive, computed, inject, onBeforeMount, onMounted, onUnmounted } from 'vue'
 import { onBeforeRouteUpdate, useRoute } from 'vue-router'
 import { getOperationDetails } from '../obp/resource-docs'
 import { ElNotification, FormInstance } from 'element-plus'
@@ -75,6 +75,16 @@ const requestForm = reactive({ url: '' })
 
 const roleFormRef = reactive<FormInstance>({})
 const roleForm = reactive({})
+
+// Real host the request will actually hit (VITE_ vars are inlined by Vite at build time,
+// so this is safe to read on the client without a server round-trip).
+const resolvedRequestUrl = computed(() => {
+  const host = import.meta.env.VITE_OBP_API_HOST
+  if (!host || !url.value) {
+    return url.value
+  }
+  return `${host}${url.value}`
+})
 
 const replaceUrlPlaceholders = () => {
   const selectedBankId = localStorage.getItem('obp-selected-bank-id')
@@ -784,6 +794,10 @@ const onError = (error) => {
         </div>
       </el-form-item>
     </el-form>
+    <el-divider class="divider" />
+    <div>
+      <p>{{ $t('preview.request_url') }}: <span id="resolved-request-url">{{ resolvedRequestUrl }}</span></p>
+    </div>
     <div class="flex-preview-panel">
       <input
         type="text"

--- a/src/language/en.json
+++ b/src/language/en.json
@@ -14,6 +14,7 @@
     "required_roles": "REQUIRED ROLES",
     "validations": "VALIDATIONS",
     "possible_errors": "POSSIBLE ERRORS",
-    "connector_methods": "CONNECTOR METHODS"
+    "connector_methods": "CONNECTOR METHODS",
+    "request_url": "REQUEST URL"
   }
 }

--- a/src/language/es.json
+++ b/src/language/es.json
@@ -14,6 +14,7 @@
     "required_roles": "RESPUESTA EXITOSA TÍPICA",
     "validations": "VALIDACIONES",
     "possible_errors": "POSIBLES ERRORES",
-    "connector_methods": " MÉTODOS DE CONECTOR"
+    "connector_methods": " MÉTODOS DE CONECTOR",
+    "request_url": "URL DE LA PETICIÓN"
   }
 }

--- a/src/language/ro.json
+++ b/src/language/ro.json
@@ -14,6 +14,7 @@
     "required_roles": "ROLURI NECESARE",
     "validations": "VALIDĂRI",
     "possible_errors": "POSIBILE ERORI",
-    "connector_methods": "METODE DE CONECTOR"
+    "connector_methods": "METODE DE CONECTOR",
+    "request_url": "URL CERERE"
   }
 }

--- a/src/test/Preview.test.ts
+++ b/src/test/Preview.test.ts
@@ -1,0 +1,76 @@
+import { mount } from '@vue/test-utils'
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+
+vi.mock('vue-router', () => ({
+  useRoute: () => ({ params: {}, query: {} }),
+  onBeforeRouteUpdate: () => {}
+}))
+
+vi.mock('../obp', () => ({
+  OBP_API_DEFAULT_RESOURCE_DOC_VERSION: 'OBPv7.0.0',
+  get: vi.fn(),
+  create: vi.fn(),
+  update: vi.fn(),
+  discard: vi.fn(),
+  createEntitlement: vi.fn(),
+  getCurrentUser: vi.fn(async () => ({})),
+  getUserEntitlements: vi.fn(async () => ({ list: [] }))
+}))
+
+vi.mock('../obp/resource-docs', () => ({
+  getOperationDetails: vi.fn()
+}))
+
+import Preview from '../components/Preview.vue'
+
+const mountPreview = () =>
+  mount(Preview, {
+    global: {
+      mocks: {
+        $t: (key: string) => key
+      }
+    }
+  })
+
+describe('Preview.vue - resolvedRequestUrl', () => {
+  const originalHost = import.meta.env.VITE_OBP_API_HOST
+
+  afterEach(() => {
+    if (originalHost === undefined) {
+      delete import.meta.env.VITE_OBP_API_HOST
+    } else {
+      import.meta.env.VITE_OBP_API_HOST = originalHost
+    }
+    vi.restoreAllMocks()
+  })
+
+  it('prefixes the resolved path with the configured OBP API host', async () => {
+    import.meta.env.VITE_OBP_API_HOST = 'http://127.0.0.1:8080'
+    const wrapper = mountPreview()
+    wrapper.vm.url = '/obp/v6.0.0/banks/gh.29.uk/accounts'
+    await wrapper.vm.$nextTick()
+
+    expect(wrapper.vm.resolvedRequestUrl).toBe('http://127.0.0.1:8080/obp/v6.0.0/banks/gh.29.uk/accounts')
+    expect(wrapper.find('#resolved-request-url').text()).toBe(
+      'http://127.0.0.1:8080/obp/v6.0.0/banks/gh.29.uk/accounts'
+    )
+  })
+
+  it('falls back to the raw path without crashing when no host is configured', async () => {
+    delete import.meta.env.VITE_OBP_API_HOST
+    const wrapper = mountPreview()
+    wrapper.vm.url = '/obp/v6.0.0/banks/gh.29.uk/accounts'
+    await wrapper.vm.$nextTick()
+
+    expect(wrapper.vm.resolvedRequestUrl).toBe('/obp/v6.0.0/banks/gh.29.uk/accounts')
+  })
+
+  it('returns an empty url as-is when nothing has been entered yet', async () => {
+    import.meta.env.VITE_OBP_API_HOST = 'http://127.0.0.1:8080'
+    const wrapper = mountPreview()
+    wrapper.vm.url = ''
+    await wrapper.vm.$nextTick()
+
+    expect(wrapper.vm.resolvedRequestUrl).toBe('')
+  })
+})


### PR DESCRIPTION
## Summary
- Add a `resolvedRequestUrl` computed to `Preview.vue` that prefixes the already-resolved request path with `VITE_OBP_API_HOST`, so users can see the real host+path an endpoint will hit before firing GET/POST/PUT/DELETE, instead of only the internal proxy path.
- Add a "REQUEST URL" info block matching the existing VALIDATIONS/POSSIBLE ERRORS/CONNECTOR METHODS visual pattern (`el-divider` + label), placed right after the URL input/method-button form.
- Add `preview.request_url` i18n key to en/es/ro.
- Add `src/test/Preview.test.ts` covering host+path concatenation, graceful fallback when the host env var is unset, and empty-url pass-through.

## Test plan
- [x] `npx vitest run src/test/Preview.test.ts` — 3/3 pass
- [x] `npx vitest run` — same pre-existing 9 failures with/without this change (verified via `git stash`), nothing regressed
- [ ] Manual browser verification (not done — this environment has no `.env`/running OBP backend to exercise the live page)