### PR TITLE
Move resolved request URL to footer as a clickable link

### DIFF
--- a/src/components/Preview.vue
+++ b/src/components/Preview.vue
@@ -794,10 +794,6 @@ const onError = (error) => {
         </div>
       </el-form-item>
     </el-form>
-    <el-divider class="divider" />
-    <div>
-      <p>{{ $t('preview.request_url') }}: <span id="resolved-request-url">{{ resolvedRequestUrl }}</span></p>
-    </div>
     <div class="flex-preview-panel">
       <input
         type="text"
@@ -928,6 +924,9 @@ const onError = (error) => {
         Implemented in: {{ footNote.version }} by function_name: {{ footNote.functionName }} (operation_id: {{ footNote.operationId }}). Message Tags: {{ footNote.messageTags }}
       </p>
     </div>
+    <div>
+      <p class="footnote">{{ $t('preview.request_url') }}: <a id="resolved-request-url" :href="resolvedRequestUrl" target="_blank" rel="noopener noreferrer">{{ resolvedRequestUrl }}</a></p>
+    </div>
     <br />
   </main>
 </template>
@@ -1052,6 +1051,18 @@ li:last-child {
 .footnote {
   color: var(--el-color-info);
   font-size: 12px;
+}
+#resolved-request-url {
+  /* Override the broad `span { font-size: 28px; }` rule above so this reads
+     the same small size as the rest of the .footnote line it lives in. Color
+     matches the surrounding .footnote text (not the browser's default link
+     blue); underline is the only visual cue that it's clickable. */
+  font-size: inherit;
+  color: inherit;
+  text-decoration: underline;
+}
+#resolved-request-url:hover {
+  color: var(--el-color-primary);
 }
 .divider {
   border-top: 1px #253047 solid;

--- a/src/components/Preview.vue
+++ b/src/components/Preview.vue
@@ -26,7 +26,7 @@
   -->
 
 <script setup lang="ts">
-import { ref, reactive, inject, onBeforeMount, onMounted, onUnmounted } from 'vue'
+import { ref, reactive, computed, inject, onBeforeMount, onMounted, onUnmounted } from 'vue'
 import { onBeforeRouteUpdate, useRoute } from 'vue-router'
 import { getOperationDetails } from '../obp/resource-docs'
 import { ElNotification, FormInstance } from 'element-plus'
@@ -75,6 +75,16 @@ const requestForm = reactive({ url: '' })
 
 const roleFormRef = reactive<FormInstance>({})
 const roleForm = reactive({})
+
+// Real host the request will actually hit (VITE_ vars are inlined by Vite at build time,
+// so this is safe to read on the client without a server round-trip).
+const resolvedRequestUrl = computed(() => {
+  const host = import.meta.env.VITE_OBP_API_HOST
+  if (!host || !url.value) {
+    return url.value
+  }
+  return `${host}${url.value}`
+})
 
 const replaceUrlPlaceholders = () => {
   const selectedBankId = localStorage.getItem('obp-selected-bank-id')
@@ -784,6 +794,10 @@ const onError = (error) => {
         </div>
       </el-form-item>
     </el-form>
+    <el-divider class="divider" />
+    <div>
+      <p>{{ $t('preview.request_url') }}: <span id="resolved-request-url">{{ resolvedRequestUrl }}</span></p>
+    </div>
     <div class="flex-preview-panel">
       <input
         type="text"

--- a/src/language/en.json
+++ b/src/language/en.json
@@ -14,6 +14,7 @@
     "required_roles": "REQUIRED ROLES",
     "validations": "VALIDATIONS",
     "possible_errors": "POSSIBLE ERRORS",
-    "connector_methods": "CONNECTOR METHODS"
+    "connector_methods": "CONNECTOR METHODS",
+    "request_url": "REQUEST URL"
   }
 }

--- a/src/language/es.json
+++ b/src/language/es.json
@@ -14,6 +14,7 @@
     "required_roles": "RESPUESTA EXITOSA TÍPICA",
     "validations": "VALIDACIONES",
     "possible_errors": "POSIBLES ERRORES",
-    "connector_methods": " MÉTODOS DE CONECTOR"
+    "connector_methods": " MÉTODOS DE CONECTOR",
+    "request_url": "URL DE LA PETICIÓN"
   }
 }

--- a/src/language/ro.json
+++ b/src/language/ro.json
@@ -14,6 +14,7 @@
     "required_roles": "ROLURI NECESARE",
     "validations": "VALIDĂRI",
     "possible_errors": "POSIBILE ERORI",
-    "connector_methods": "METODE DE CONECTOR"
+    "connector_methods": "METODE DE CONECTOR",
+    "request_url": "URL CERERE"
   }
 }

--- a/src/test/Preview.test.ts
+++ b/src/test/Preview.test.ts
@@ -1,0 +1,76 @@
+import { mount } from '@vue/test-utils'
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+
+vi.mock('vue-router', () => ({
+  useRoute: () => ({ params: {}, query: {} }),
+  onBeforeRouteUpdate: () => {}
+}))
+
+vi.mock('../obp', () => ({
+  OBP_API_DEFAULT_RESOURCE_DOC_VERSION: 'OBPv7.0.0',
+  get: vi.fn(),
+  create: vi.fn(),
+  update: vi.fn(),
+  discard: vi.fn(),
+  createEntitlement: vi.fn(),
+  getCurrentUser: vi.fn(async () => ({})),
+  getUserEntitlements: vi.fn(async () => ({ list: [] }))
+}))
+
+vi.mock('../obp/resource-docs', () => ({
+  getOperationDetails: vi.fn()
+}))
+
+import Preview from '../components/Preview.vue'
+
+const mountPreview = () =>
+  mount(Preview, {
+    global: {
+      mocks: {
+        $t: (key: string) => key
+      }
+    }
+  })
+
+describe('Preview.vue - resolvedRequestUrl', () => {
+  const originalHost = import.meta.env.VITE_OBP_API_HOST
+
+  afterEach(() => {
+    if (originalHost === undefined) {
+      delete import.meta.env.VITE_OBP_API_HOST
+    } else {
+      import.meta.env.VITE_OBP_API_HOST = originalHost
+    }
+    vi.restoreAllMocks()
+  })
+
+  it('prefixes the resolved path with the configured OBP API host', async () => {
+    import.meta.env.VITE_OBP_API_HOST = 'http://127.0.0.1:8080'
+    const wrapper = mountPreview()
+    wrapper.vm.url = '/obp/v6.0.0/banks/gh.29.uk/accounts'
+    await wrapper.vm.$nextTick()
+
+    expect(wrapper.vm.resolvedRequestUrl).toBe('http://127.0.0.1:8080/obp/v6.0.0/banks/gh.29.uk/accounts')
+    expect(wrapper.find('#resolved-request-url').text()).toBe(
+      'http://127.0.0.1:8080/obp/v6.0.0/banks/gh.29.uk/accounts'
+    )
+  })
+
+  it('falls back to the raw path without crashing when no host is configured', async () => {
+    delete import.meta.env.VITE_OBP_API_HOST
+    const wrapper = mountPreview()
+    wrapper.vm.url = '/obp/v6.0.0/banks/gh.29.uk/accounts'
+    await wrapper.vm.$nextTick()
+
+    expect(wrapper.vm.resolvedRequestUrl).toBe('/obp/v6.0.0/banks/gh.29.uk/accounts')
+  })
+
+  it('returns an empty url as-is when nothing has been entered yet', async () => {
+    import.meta.env.VITE_OBP_API_HOST = 'http://127.0.0.1:8080'
+    const wrapper = mountPreview()
+    wrapper.vm.url = ''
+    await wrapper.vm.$nextTick()
+
+    expect(wrapper.vm.resolvedRequestUrl).toBe('')
+  })
+})


### PR DESCRIPTION
## Summary
- Moved the resolved-request-url line out from under the request form and down next to the "Implemented in" footnote at the bottom of the preview panel, using the same `.footnote` styling instead of an unstyled `<p>` that rendered at a jarring large size/default link color.
- Root cause of the sizing issue: a broad `span { font-size: 28px; }` rule in this component's scoped styles applied regardless of where the span was placed. Added a higher-specificity `#resolved-request-url` rule to keep it at the footnote's 12px/muted color, with only an underline as the clickability cue.
- Turned it into an actual link (`target="_blank"`, `rel="noopener noreferrer"`) so users can click through to the resolved request URL directly instead of only reading it.
